### PR TITLE
SP-728 - Update views to use comment author rather than node author for l

### DIFF
--- a/docroot/profiles/drupal_commons/modules/features/commons_discussion/commons_discussion.views_default.inc
+++ b/docroot/profiles/drupal_commons/modules/features/commons_discussion/commons_discussion.views_default.inc
@@ -639,6 +639,17 @@ function commons_discussion_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -669,7 +680,7 @@ function commons_discussion_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -767,9 +778,12 @@ function commons_discussion_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
     'group_nid' => array(
       'label' => 'Groups',
@@ -926,6 +940,17 @@ function commons_discussion_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -956,7 +981,7 @@ function commons_discussion_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -1054,9 +1079,12 @@ function commons_discussion_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
   ));
   $handler->override_option('sorts', array(

--- a/docroot/profiles/drupal_commons/modules/features/commons_document/commons_document.views_default.inc
+++ b/docroot/profiles/drupal_commons/modules/features/commons_document/commons_document.views_default.inc
@@ -639,6 +639,17 @@ function commons_document_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -669,7 +680,7 @@ function commons_document_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -767,9 +778,12 @@ function commons_document_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name_1',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
     'group_nid' => array(
       'label' => 'Groups',
@@ -926,6 +940,17 @@ function commons_document_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -956,7 +981,7 @@ function commons_document_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -1054,9 +1079,12 @@ function commons_document_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
   ));
   $handler->override_option('sorts', array(

--- a/docroot/profiles/drupal_commons/modules/features/commons_event/commons_event.views_default.inc
+++ b/docroot/profiles/drupal_commons/modules/features/commons_event/commons_event.views_default.inc
@@ -1618,6 +1618,17 @@ function commons_event_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -1648,7 +1659,7 @@ function commons_event_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -1746,9 +1757,12 @@ function commons_event_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
     'group_nid' => array(
       'label' => 'Groups',
@@ -3552,6 +3566,17 @@ function commons_event_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -3582,7 +3607,7 @@ function commons_event_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -3680,12 +3705,12 @@ function commons_event_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
-      'relationship' => 'none',
     ),
   ));
   $handler->override_option('sorts', array(

--- a/docroot/profiles/drupal_commons/modules/features/commons_poll/commons_poll.views_default.inc
+++ b/docroot/profiles/drupal_commons/modules/features/commons_poll/commons_poll.views_default.inc
@@ -1053,6 +1053,17 @@ function commons_poll_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -1083,7 +1094,7 @@ function commons_poll_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -1181,9 +1192,12 @@ function commons_poll_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
   ));
   $handler->override_option('sorts', array(
@@ -2362,6 +2376,17 @@ function commons_poll_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -2392,7 +2417,7 @@ function commons_poll_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -2490,9 +2515,12 @@ function commons_poll_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
     'group_nid' => array(
       'label' => 'Groups',

--- a/docroot/profiles/drupal_commons/modules/features/commons_wiki/commons_wiki.views_default.inc
+++ b/docroot/profiles/drupal_commons/modules/features/commons_wiki/commons_wiki.views_default.inc
@@ -1039,6 +1039,17 @@ function commons_wiki_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -1069,7 +1080,7 @@ function commons_wiki_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -1167,9 +1178,12 @@ function commons_wiki_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
   ));
   $handler->override_option('sorts', array(
@@ -1948,6 +1962,17 @@ function commons_wiki_views_default_views() {
       ),
       'relationship' => 'none',
     ),
+    'uid' => array(
+      'label' => 'Comment Author',
+      'required' => 0,
+      'id' => 'uid',
+      'table' => 'comments',
+      'field' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
+      'relationship' => 'none',
+    ),
   ));
   $handler->override_option('fields', array(
     'picture' => array(
@@ -1978,7 +2003,7 @@ function commons_wiki_views_default_views() {
       'id' => 'picture',
       'table' => 'users',
       'field' => 'picture',
-      'relationship' => 'nid',
+      'relationship' => 'uid',
       'override' => array(
         'button' => 'Override',
       ),
@@ -2076,9 +2101,12 @@ function commons_wiki_views_default_views() {
       'link_to_user' => 1,
       'exclude' => 0,
       'id' => 'name',
-      'table' => 'comments',
+      'table' => 'users',
       'field' => 'name',
-      'relationship' => 'none',
+      'relationship' => 'uid',
+      'override' => array(
+        'button' => 'Override',
+      ),
     ),
     'group_nid' => array(
       'label' => 'Groups',


### PR DESCRIPTION
SP-728 - Update views to use comment author rather than node author for latest comments. Re-applied to latest github version which had a partial fix in place (i.e. it fixes comment username but still shows the node author's picture)
